### PR TITLE
Set online and playing status for the bot

### DIFF
--- a/pgsbot.py
+++ b/pgsbot.py
@@ -17,6 +17,10 @@ class PgsBot(discord.Client):
     async def on_ready(self):
         print('Logged in as {0}.'.format(self.user))
 
+        await self.change_presence(
+                status = discord.status.online,
+                activity = discord.Game(name='Pokémon GO'))
+
     def test_mode(self):
         return config['bot'].getboolean('test_mode')
 


### PR DESCRIPTION
Pretty much does what it says on the tin. change_presence() is a method
on the `discord.Client` class we extend, so we can get to it through
`self`. We pass two named parameters in, one to set the status online.

Status doesn't really need to be set, online is the default, but it
makes it easier to change if you should ever decide on 'idle'.
All the available status options you can set are at this link:
https://discordpy.readthedocs.io/en/rewrite/api.html#discord.Status

We set activity by passing a custom `discord.Game` data class as the
value for the `activity` option. It only takes one option for bots, and
that's the name, which we make up ourselves.